### PR TITLE
Enable mxnet-haskell with the latest MXNet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,11 @@ before_install:
   - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-4.8 /usr/bin/gcc
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-4.8 /usr/bin/g++
   # Build mxnet library.
-  - git clone https://github.com/dmlc/mxnet.git ~/mxnet --recursive
-  - cd ~/mxnet && git checkout v0.9.3 && make && cd ~
+  - git clone https://github.com/apache/incubator-mxnet ~/mxnet --recursive
+  - cd ~/mxnet/nnvm && git checkout master && git pull
+  - cd ~/mxnet/nnvm/dmlc-core && git checkout master && git pull
+  - cd ~/mxnet/dmlc-core && git checkout master && git pull
+  - cd ~/mxnet && make
   - mkdir -p ~/.local/lib
   - cp -f ~/mxnet/lib/libmxnet.so ~/.local/lib/
   - export LIBRARY_PATH=~/.local/lib:$LIBRARY_PATH

--- a/mxnet/src/MXNet/Core/Base/DType.hs
+++ b/mxnet/src/MXNet/Core/Base/DType.hs
@@ -139,6 +139,10 @@ class Tensor tensor => Neural tensor where
     batchNorm
         :: DType a
         => tensor a     -- ^ Input data to batch normalization.
+        -> tensor a     -- ^ Gamma
+        -> tensor a     -- ^ Beta
+        -> tensor a     -- ^ Moving mean
+        -> tensor a     -- ^ Moving var
         -> tensor a
     -- | An operator taking in a n-dimensional input tensor (n > 2), and normalizing the input by subtracting the mean
     -- and variance calculated over the spatial dimensions.
@@ -308,7 +312,8 @@ class Tensor tensor => Neural tensor where
     -- | Custom operator implemented in frontend.
     custom
         :: DType a
-        => String     -- ^ Type of custom operator, must be registered first.
+        => [tensor a] -- ^ Input of custom operator
+        -> String     -- ^ Type of custom operator, must be registered first.
         -> tensor a
 
 

--- a/mxnet/src/MXNet/Core/Base/Internal/Raw.chs
+++ b/mxnet/src/MXNet/Core/Base/Internal/Raw.chs
@@ -222,7 +222,7 @@ mxNDArrayGetShape handle = do
 -- | Get the content of the data in NDArray.
 {#fun MXNDArrayGetData as mxNDArrayGetData
     { id `NDArrayHandle'            -- ^ The NDArray handle.
-    , alloca- `Ptr MXFloat' peek*
+    , alloca- `Ptr ()' peek*
     } -> `Int' -- ^ Pointer holder to get pointer of data.
     #}
 

--- a/mxnet/src/MXNet/Core/Base/Internal/TH.hs
+++ b/mxnet/src/MXNet/Core/Base/Internal/TH.hs
@@ -24,9 +24,7 @@ registerNDArrayOps :: Bool      -- ^ If support "out" key in argument dictionary
                    -> Q [Dec]
 registerNDArrayOps mutable = runIO $ do
     (_, names) <- mxListAllOpNames
-    ds0 <- mapM (register mutable) names
-    let ds = concat ds0
-    return ds
+    concat <$> mapM (register mutable) names
   where
     register mutable _name = do
         (_, handle) <- nnGetOpHandle _name
@@ -37,9 +35,7 @@ registerNDArrayOps mutable = runIO $ do
 registerSymbolOps :: Q [Dec]
 registerSymbolOps = runIO $ do
     (_, names) <- mxListAllOpNames
-    ds0 <- mapM register names
-    let ds = concat ds0
-    return ds
+    concat <$> mapM register names
   where
     register _name = do
         (_, handle) <- nnGetOpHandle _name
@@ -165,8 +161,6 @@ makeNDArrayFunc mutable _name desc argv argtype = do
                         AllPhases
 
         fun = FunD (mkName name) [Clause (ndarrayArgP <> ordinaryArgP <> implicitArgP <> returnArgP) func []]
-
-    print $ ppr fun
 
 
     return $ if null argv || deprecated
@@ -335,7 +329,7 @@ makeSymbolFunc _name desc argv argtype = do
 
         fun = FunD (mkName name) [Clause (nameArgP <> ndarrayArgP <> ordinaryArgP <> implicitArgP) func []]
 
-        
+
     return $ if null argv || deprecated
                           || alias
                           || _name `elem` ["_NDArray", "_Native", "_arange"]

--- a/mxnet/src/MXNet/Core/Base/Internal/TH/NDArray.hs
+++ b/mxnet/src/MXNet/Core/Base/Internal/TH/NDArray.hs
@@ -29,7 +29,7 @@ import MXNet.Core.Base.Internal
 import MXNet.Core.Base.Internal.TH (registerNDArrayOps)
 import MXNet.Core.NNVM.Internal (nnGetOpHandle)
 import Prelude hiding (sin, sinh, cos, cosh, tan, tanh, min, max, round, floor,
-                       abs, sum, sqrt, log, exp, flip, concat)
+                       abs, sum, sqrt, log, exp, flip, concat, reverse, repeat)
 
 -- | Result representation for generic NDArray op.
 class NDArrayOpResult a where

--- a/mxnet/src/MXNet/Core/Base/Internal/TH/Symbol.hs
+++ b/mxnet/src/MXNet/Core/Base/Internal/TH/Symbol.hs
@@ -29,7 +29,7 @@ import MXNet.Core.Base.Internal
 import MXNet.Core.Base.Internal.TH (registerSymbolOps)
 import MXNet.Core.NNVM.Internal (nnGetOpHandle, nnSymbolCompose)
 import Prelude hiding (sin, sinh, cos, cosh, tan, tanh, min, max, round, floor,
-                       abs, sum, sqrt, log, exp, flip, concat)
+                       abs, sum, sqrt, log, exp, flip, concat, repeat, reverse)
 
 -- | Register symbol operators.
 $(registerSymbolOps)

--- a/mxnet/src/MXNet/Core/Base/NDArray.hs
+++ b/mxnet/src/MXNet/Core/Base/NDArray.hs
@@ -424,9 +424,13 @@ instance Neural NDArray where
     dropout input p = NDArray . unsafePerformIO $ do
         let handle1 = getHandle input
         I.dropout handle1 (add @"p" p nil)
-    batchNorm input = NDArray . unsafePerformIO $ do
+    batchNorm input gm bt mm mv = NDArray . unsafePerformIO $ do
         let handle1 = getHandle input
-        I.batchnorm handle1 nil
+        let handle2 = getHandle gm
+        let handle3 = getHandle bt
+        let handle4 = getHandle mm
+        let handle5 = getHandle mv
+        I.batchnorm handle1 handle2 handle3 handle4 handle5 nil
     instanceNorm input gamma beta eps = NDArray . unsafePerformIO $ do
         let handle1 = getHandle input
             handle2 = getHandle gamma
@@ -475,5 +479,6 @@ instance Neural NDArray where
     blockGrad input = NDArray . unsafePerformIO $ do
         let handle1 = getHandle input
         I.blockgrad handle1
-    custom op = NDArray . unsafePerformIO $ do
-        I.custom op
+    custom input op = NDArray . unsafePerformIO $ do
+        let handles = map getHandle input
+        I.custom handles op

--- a/mxnet/src/MXNet/Core/Base/Symbol.hs
+++ b/mxnet/src/MXNet/Core/Base/Symbol.hs
@@ -412,10 +412,14 @@ instance Neural Symbol where
         let handle1 = getHandle input
         name <- naming "Dropout"
         I.dropout name handle1 (add @"p" p nil)
-    batchNorm input = Symbol . unsafePerformIO $ do
+    batchNorm input gm bt mm mv = Symbol . unsafePerformIO $ do
         let handle1 = getHandle input
+        let handle2 = getHandle gm
+        let handle3 = getHandle bt
+        let handle4 = getHandle mm
+        let handle5 = getHandle mv
         name <- naming "BatchNorm"
-        I.batchnorm name handle1 nil
+        I.batchnorm name handle1 handle2 handle3 handle4 handle5 nil
     instanceNorm input gamma beta eps = Symbol . unsafePerformIO $ do
         let handle1 = getHandle input
             handle2 = getHandle gamma
@@ -459,6 +463,7 @@ instance Neural Symbol where
         let handle1 = getHandle input
         name <- naming "BlockGrad"
         I.blockgrad name handle1
-    custom op = Symbol . unsafePerformIO $ do
+    custom input op = Symbol . unsafePerformIO $ do
+        let handles = map getHandle input
         name <- naming "Custom"
-        I.custom name op
+        I.custom name handles op


### PR DESCRIPTION
The latest mxnet 0.11+ has a few updates and the haskell binding needs some modification accordingly.